### PR TITLE
Add dark mode and a shared design-token layer across the site

### DIFF
--- a/.claude/agent-memory-local/doer-doer-worker-do/MEMORY.md
+++ b/.claude/agent-memory-local/doer-doer-worker-do/MEMORY.md
@@ -1,0 +1,2 @@
+- [Jest resetMocks gotcha](jest-resetmocks-gotcha.md) — CRA's resetMocks:true wipes jest.mock() factory implementations; set them in the test body instead.
+- [react-bootstrap ESM imports break Jest](react-bootstrap-esm-imports.md) — never `react-bootstrap/esm/*`; use named imports from the package root.

--- a/.claude/agent-memory-local/doer-doer-worker-do/jest-resetmocks-gotcha.md
+++ b/.claude/agent-memory-local/doer-doer-worker-do/jest-resetmocks-gotcha.md
@@ -1,0 +1,12 @@
+---
+name: jest-resetmocks-gotcha
+description: CRA's jest config sets resetMocks:true — inline jest.fn() implementations set inside a jest.mock() factory get wiped before every test
+metadata:
+  type: project
+---
+
+`react-scripts`' default Jest config (`node_modules/react-scripts/scripts/utils/createJestConfig.js`) sets `resetMocks: true`. This resets every `jest.fn()`'s implementation/return-value **before each test runs** — including ones set inline inside a `jest.mock('./module', () => ({ fn: jest.fn(() => ...) }))` factory. The factory only runs once at module-mock-setup time; the reset then strips the implementation, so `fn()` returns `undefined` in the actual test, not what the factory specified.
+
+**Why:** discovered fixing `src/App.test.tsx` for `[[ux-refresh-dark-mode]]` Phase 0 (Q2 zero-th step) — a mock of `fetchSiteData` returning `new Promise(() => {})` (kept pending on purpose) silently became `undefined`, producing `Cannot read properties of undefined (reading 'then')` with no indication resetMocks was the cause.
+
+**How to apply:** when mocking a module in this repo, declare the mock with a bare `jest.fn()` in the `jest.mock(...)` factory, then set the concrete behavior (`.mockReturnValue(...)` / `.mockImplementation(...)`) inside the test body (or a `beforeEach`), never only inside the factory.

--- a/.claude/agent-memory-local/doer-doer-worker-do/react-bootstrap-esm-imports.md
+++ b/.claude/agent-memory-local/doer-doer-worker-do/react-bootstrap-esm-imports.md
@@ -1,0 +1,12 @@
+---
+name: react-bootstrap-esm-imports
+description: Never import from react-bootstrap/esm/* — breaks Jest's transform; use named imports from the react-bootstrap package root (CJS) instead
+metadata:
+  type: project
+---
+
+`react-bootstrap`'s package.json points `"main"` at `cjs/index.js` and `"module"` at `esm/index.js`. A direct deep import like `import Stack from "react-bootstrap/esm/Stack"` bypasses the `main` field entirely and pulls in raw ESM (`import classNames from 'classnames'`), which CRA's default Jest `transformIgnorePatterns` does not transform inside `node_modules` — any test that touches that import chain fails with `SyntaxError: Cannot use import statement outside a module`.
+
+**Why:** found in `src/App.tsx` (pre-existing `import Stack from "react-bootstrap/esm/Stack"`) while fixing the stale `App.test.tsx` gate for `[[ux-refresh-dark-mode]]` Phase 0 — the test couldn't even parse until this was fixed.
+
+**How to apply:** always import react-bootstrap components as named imports from the package root, e.g. `import { Stack } from "react-bootstrap";` (matches how the rest of the codebase already imports `Navbar`/`Nav`/`OverlayTrigger`/etc. in `appheader.component.tsx`) — never `react-bootstrap/esm/...`.

--- a/.claude/dotest.txt
+++ b/.claude/dotest.txt
@@ -1,0 +1,1 @@
+npm test -- --watchAll=false

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+CLAUDE.local.md
+.claude/settings.local.json
+.claude/agent-memory-local/
+tmp/
+
 # dependencies
 /node_modules
 /.pnp

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "scripts": {
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
+    "publish": "npm run build && gh-pages -d build",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",

--- a/src/App.scss
+++ b/src/App.scss
@@ -1,8 +1,86 @@
 :root {
+  // Brand colors (unchanged from original — evolution, not rebrand; same in
+  // both themes since these carry the site's identity, not surface color).
   --app-heading-background-color: #3D6B8F;
   --app-heading-background-hover: #3d6c8f83;
   --app-heading-color: #D6D4D0;
   --app-content-background-color: #D6D4D0;
+
+  // Semantic layer
+  --app-text-primary: #212529;
+  --app-text-secondary: #495057;
+  --app-border-color: rgba(0, 0, 0, 0.15);
+  --app-shadow-color: rgba(0, 0, 0, 0.2);
+  --app-link-color: var(--app-heading-background-color);
+  --app-link-hover-color: var(--app-heading-background-hover);
+  --app-surface-background: var(--app-content-background-color);
+  --app-surface-background-alt: #ffffff;
+  --app-difficulty-easy: rgb(var(--bs-success-rgb));
+  --app-difficulty-moderate: rgb(var(--bs-primary-rgb));
+  --app-difficulty-hard: rgb(var(--bs-danger-rgb));
+
+  // Loading spinner: brand blue reads fine on the light body background
+  // (matches the card-header color), but is low-contrast on dark — overridden
+  // below rather than tied 1:1 to a single token in both directions.
+  --app-spinner-color: var(--app-heading-background-color);
+
+  // Body background tint (topo image stays the same asset in both themes;
+  // only the multiply-blended tint color changes — see index.scss).
+  --app-body-tint: transparent;
+
+  // Spacing scale
+  --app-space-1: 0.25rem;
+  --app-space-2: 0.5rem;
+  --app-space-3: 1rem;
+  --app-space-4: 1.5rem;
+  --app-space-5: 2rem;
+
+  // Radius scale
+  --app-radius-sm: 0.25rem;
+  --app-radius-md: 0.5rem;
+  --app-radius-lg: 1rem;
+
+  // Transitions
+  --app-transition-duration: 150ms;
+  --app-transition-duration-slow: 300ms;
+  --app-transition-easing: ease-in-out;
+
+  // Typography scale (same in both themes — typography isn't theme-dependent)
+  --app-font-size-sm: 0.875rem;
+  --app-font-size-base: 1rem;
+  --app-font-size-lg: 1.25rem;
+  --app-font-size-xl: 1.5rem;
+  --app-font-size-xxl: 2rem;
+  --app-line-height-tight: 1.2;
+  --app-line-height-base: 1.5;
+  --app-font-weight-bold: 700;
+}
+
+:root[data-theme="dark"] {
+  // Retint Bootstrap's CDN-loaded contextual colors so text-success/
+  // text-primary/text-dark/text-danger and Badge bg="..." (difficulty icons,
+  // favorite icon, goal-status icons, badges) go dark-safe sitewide with no
+  // per-component changes (Q1).
+  --bs-success-rgb: 61, 191, 110;
+  --bs-primary-rgb: 77, 144, 254;
+  --bs-dark-rgb: 233, 236, 239;
+  --bs-danger-rgb: 255, 99, 99;
+  --bs-secondary-rgb: 134, 142, 150;
+
+  --app-text-primary: #E8E6E3;
+  --app-text-secondary: #ADB5BD;
+  --app-spinner-color: var(--app-text-primary);
+  --app-border-color: rgba(255, 255, 255, 0.15);
+  // Flat black at low opacity disappears against the already-dark
+  // --app-surface-background (#1E2227); bumped opacity + carddeck's larger
+  // blur radius (Phase 1) make it read as a real soft-elevation halo instead.
+  --app-shadow-color: rgba(0, 0, 0, 0.75);
+  --app-link-color: #6FA8DC;
+  --app-link-hover-color: #8FBEE0;
+  --app-surface-background: #1E2227;
+  --app-surface-background-alt: #262B31;
+
+  --app-body-tint: rgba(20, 24, 28, 0.55);
 }
 
 .app {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,25 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import App from './App';
+import { fetchSiteData } from './services/data.service';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+jest.mock('./services/data.service', () => ({
+  fetchSiteData: jest.fn(),
+}));
+
+test('renders the app header navigation', () => {
+  // Site data is fetched over the network in a real render; keep it pending
+  // so the test only exercises the always-rendered shell (AppHeader), not
+  // the fetch lifecycle. react-scripts' jest config resets mock
+  // implementations before each test, so this has to be wired up here
+  // rather than in the jest.mock factory above.
+  (fetchSiteData as jest.Mock).mockReturnValue(new Promise(() => {}));
+
+  render(
+    <MemoryRouter>
+      <App />
+    </MemoryRouter>
+  );
+  expect(screen.getByText(/Goals/i)).toBeInTheDocument();
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,24 @@
 import "./App.scss";
 import ClimbingBoxLoader from "react-spinners/ClimbingBoxLoader";
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
 import { Outlet } from "react-router-dom";
 import { ISiteData, fetchSiteData } from "./services/data.service";
+import { getInitialTheme } from "./services/theme.service";
 import { IPageLayoutProps, PageLayout } from "./layouts/page.layout";
 import { AppHeader } from "./components/appheader.component";
-import Stack from "react-bootstrap/esm/Stack";
+import { Stack } from "react-bootstrap";
 
 export default function App() {
   const [data, setData] = useState({});
   const [isLoaded, setIsLoaded] = useState(false);
   const props: IPageLayoutProps = { data };
+
+  // Applied synchronously before the browser paints, independent of the data
+  // fetch below, so there's no flash of the wrong theme while isLoaded is
+  // still false.
+  useLayoutEffect(() => {
+    document.documentElement.dataset.theme = getInitialTheme();
+  }, []);
 
   useEffect(() => {
     console.log("Fetching site data...");
@@ -34,7 +42,7 @@ export default function App() {
         <Stack className="mt-5">
           <ClimbingBoxLoader 
             size={20}
-            color="var(--app-heading-background-color)"
+            color="var(--app-spinner-color)"
             cssOverride={{ margin: "auto" }}
           />
         </Stack>

--- a/src/components/appheader.component.scss
+++ b/src/components/appheader.component.scss
@@ -3,7 +3,7 @@
 }
 
 header {
-    margin-top: 0.75em;
+    margin-top: var(--app-space-3);
 
     .card .card-body {
         padding: 0;
@@ -24,6 +24,24 @@ header {
         .nav-link {
             color: var(--app-heading-color) !important;
             border-left: 1px solid #999999;
+            transition: background-color var(--app-transition-duration) var(--app-transition-easing);
+
+            &:hover {
+                background-color: var(--app-heading-background-hover);
+            }
+
+            &:focus-visible {
+                outline: 2px solid var(--app-heading-color);
+                outline-offset: -2px;
+            }
+
+            &.theme-toggle-button {
+                background: transparent;
+                border-top: none;
+                border-right: none;
+                border-bottom: none;
+                cursor: pointer;
+            }
         }
     }
 }

--- a/src/components/appheader.component.tsx
+++ b/src/components/appheader.component.tsx
@@ -1,11 +1,12 @@
 import "./appheader.component.scss";
 import { Navbar, Nav, OverlayTrigger, Tooltip } from "react-bootstrap";
-import { ReactNode } from "react";
+import { ReactNode, useState } from "react";
 import { LinkContainer } from "react-router-bootstrap";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faFacebookF, faGithub } from "@fortawesome/free-brands-svg-icons";
-import { faHiking } from "@fortawesome/free-solid-svg-icons";
+import { faHiking, faMoon, faSun } from "@fortawesome/free-solid-svg-icons";
+import { Theme, getInitialTheme, setTheme } from "../services/theme.service";
 
 interface INavLinkWithTooltipProps {
   href?: string;
@@ -30,6 +31,40 @@ function NavLinkWithTooltip({
       }
     >
       <Nav.Link href={href}>{children}</Nav.Link>
+    </OverlayTrigger>
+  );
+}
+
+function ThemeToggle() {
+  const [theme, setThemeState] = useState<Theme>(() => getInitialTheme());
+  const nextTheme: Theme = theme === "dark" ? "light" : "dark";
+  const tooltip =
+    theme === "dark" ? "Switch to light mode" : "Switch to dark mode";
+
+  function toggleTheme() {
+    setTheme(nextTheme);
+    setThemeState(nextTheme);
+  }
+
+  return (
+    <OverlayTrigger
+      placement="bottom"
+      delay={{ show: 300, hide: 150 }}
+      overlay={
+        <Tooltip id="tooltip-theme-toggle" className="appheader-tooltip">
+          {tooltip}
+        </Tooltip>
+      }
+    >
+      <Nav.Link
+        as="button"
+        type="button"
+        className="theme-toggle-button"
+        aria-label={tooltip}
+        onClick={toggleTheme}
+      >
+        <FontAwesomeIcon icon={theme === "dark" ? faSun : faMoon} />
+      </Nav.Link>
     </OverlayTrigger>
   );
 }
@@ -72,6 +107,7 @@ export function AppHeader() {
               >
                 <FontAwesomeIcon icon={faGithub} size="lg" />
               </NavLinkWithTooltip>
+              <ThemeToggle />
             </Nav>
           </Navbar>
         </div>

--- a/src/components/carddeck.component.scss
+++ b/src/components/carddeck.component.scss
@@ -1,19 +1,19 @@
 .card-deck-header {
-    margin-bottom: 0.5em;
+    margin-bottom: var(--app-space-2);
     .card-body {
-        font-size: small;
-        padding: 0.5em;
+        font-size: var(--app-font-size-sm);
+        padding: var(--app-space-2);
     }
 }
 
 .card-deck {
     max-width: unset;
     .row {
-        gap: 0.5em;
+        gap: var(--app-space-2);
         justify-content: space-between;
     }
     .col {
-        margin-bottom: 0.5em;
+        margin-bottom: var(--app-space-2);
     }
     .card {
         margin: 0;
@@ -22,8 +22,12 @@
         min-height: fit-content;
         height: 100%;
 
+        &:hover {
+            box-shadow: 0 var(--app-space-3) var(--app-space-5) var(--app-shadow-color);
+        }
+
         .card-body {
-            font-size: smaller;
+            font-size: var(--app-font-size-sm);
 
             hr:last-child {
                 /* If there's nothing after the hr, then don't display it. */
@@ -46,18 +50,20 @@
 .card {
     width: 100%;
     padding: 0;
-    background-color: var(--app-content-background-color);
+    background-color: var(--app-surface-background);
     border: 2px solid var(--app-heading-background-color);
-    box-shadow: 2px 2px 2px 1px rgba(0, 0, 0, 0.2);
+    border-radius: var(--app-radius-md);
+    box-shadow: 0 var(--app-space-2) var(--app-space-4) var(--app-shadow-color);
+    transition: box-shadow var(--app-transition-duration) var(--app-transition-easing);
 
     .card-header {
         background-color: var(--app-heading-background-color);
         color: var(--app-heading-color);
         border-top-left-radius: 0;
         border-top-right-radius: 0;
-        font-weight: bold;
-        padding: 0.25em;
-        font-size: 1.1em;
+        font-weight: var(--app-font-weight-bold);
+        padding: var(--app-space-1);
+        font-size: var(--app-font-size-lg);
         width: 100%;
 
         &:has(.card-body) {
@@ -76,8 +82,8 @@
     }
 
     .card-footer {
-        padding: 0.25em;
-        font-size: 1em;
+        padding: var(--app-space-1);
+        font-size: var(--app-font-size-base);
         width: 100%;
     }
 }

--- a/src/components/ebrpgoal.component.scss
+++ b/src/components/ebrpgoal.component.scss
@@ -1,6 +1,17 @@
 .ebrp-goal-list {
+    margin-bottom: var(--app-space-4);
+
+    &:last-child {
+        margin-bottom: 0;
+    }
+
     ul {
         column-count: 6;
         column-width: 150px;
+        gap: var(--app-space-2);
+    }
+
+    li {
+        margin-bottom: var(--app-space-1);
     }
 }

--- a/src/components/hikedeck.component.scss
+++ b/src/components/hikedeck.component.scss
@@ -1,10 +1,14 @@
 .card-header {
     a:has(svg) {
+        padding: var(--app-space-1);
+        border-radius: var(--app-radius-sm);
+        transition: background-color var(--app-transition-duration) var(--app-transition-easing);
+
         &:hover {
             background-color: var(--app-heading-background-hover);
         }
     }
 }
 .card-footer {
-    font-size: unset !important; // set to smaller globally
+    font-size: var(--app-font-size-sm) !important; // smaller than the base .card-footer size
 }

--- a/src/components/hikelist.component.scss
+++ b/src/components/hikelist.component.scss
@@ -1,5 +1,5 @@
 .hike-list-card {
-    margin-bottom: 0.5em;
+    margin-bottom: var(--app-space-2);
     .list-group-item:last-of-type {
         margin-bottom: 0;
     }
@@ -7,27 +7,16 @@
 
 ul.hike-list {
     .list-group-item {
-        margin-bottom: 0.5em;
+        margin-bottom: var(--app-space-2);
     }
 
     li {
-        border-radius: 6px;
-        background-color: var(--app-content-background-color);
+        border-radius: var(--app-radius-sm);
+        background-color: var(--app-surface-background);
+        color: var(--app-text-primary);
         border: 1px solid var(--app-heading-background-color) !important;
 
-        padding: 0.25em 0.5em;
-        &.easy-hike .hike-difficulty-icon {
-            color: green;
-        }
-        &.moderate-hike .hike-difficulty-icon {
-            color: blue;
-        }
-        &.hard-hike .hike-difficulty-icon {
-            color: black;
-        }
-        &.unknown-hike .hike-difficulty-icon {
-            color: var(--app-content-background-color);
-        }
+        padding: var(--app-space-1) var(--app-space-2);
         .hike-info {
             white-space: nowrap;
             text-align: center;

--- a/src/components/parkdeck.component.scss
+++ b/src/components/parkdeck.component.scss
@@ -7,13 +7,21 @@
     background-color: var(--app-heading-background-color);
     color: var(--app-heading-color);
     border: 2px solid var(--app-heading-color);
-    font-size: small;
-    padding: 0.25em 0.5em;
+    font-size: var(--app-font-size-sm);
+    padding: var(--app-space-1) var(--app-space-2);
     + .dropdown-menu {
       height: 300px;
       overflow-y: scroll;
-      background-color: var(--app-content-background-color);
+      background-color: var(--app-surface-background);
       border: 2px solid var(--app-heading-background-color);
+
+      .dropdown-item {
+        color: var(--app-text-primary);
+
+        &:hover {
+          color: var(--app-text-primary);
+        }
+      }
     }
     &,
     + .dropdown-menu {
@@ -23,12 +31,12 @@
 }
 
 .card-deck {
-  gap: 0.25em;
+  gap: var(--app-space-1);
   .card {
     width: 100%;
 
     .card-footer {
-      font-size: smaller;
+      font-size: var(--app-font-size-sm);
     }
 
     .card-body {

--- a/src/components/utils.component.scss
+++ b/src/components/utils.component.scss
@@ -6,5 +6,5 @@
 .badge-transparent {
     border: none;
     background-color: rgba(0, 0, 0, 0) !important;
-    color: var(--bs-list-group-color);
+    color: var(--app-text-primary);
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,6 +1,9 @@
 body {
   margin: 0;
   font-family: Roboto, Helvetica, Arial, sans-serif;
+  font-size: var(--app-font-size-base);
+  line-height: var(--app-line-height-base);
+  color: var(--app-text-primary);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 
@@ -9,6 +12,25 @@ body {
   background-size: auto;
   background-repeat: repeat;
   background-attachment: scroll;
+  background-color: var(--app-body-tint);
+  background-blend-mode: multiply;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-weight: var(--app-font-weight-bold);
+  line-height: var(--app-line-height-tight);
+}
+
+h1 {
+  font-size: var(--app-font-size-xxl);
+}
+
+h2 {
+  font-size: var(--app-font-size-xl);
+}
+
+h3 {
+  font-size: var(--app-font-size-lg);
 }
 
 code {

--- a/src/pages/error.page.tsx
+++ b/src/pages/error.page.tsx
@@ -6,7 +6,7 @@ export default function ErrorPage() {
   console.error(error);
 
   return (
-    <div className="App">
+    <div className="app loaded">
       <AppHeader />
       <section id="content" className="card loaded">
         <div className="card-body">

--- a/src/services/theme.service.test.tsx
+++ b/src/services/theme.service.test.tsx
@@ -1,0 +1,49 @@
+import { getInitialTheme, setTheme, THEME_STORAGE_KEY } from "./theme.service";
+
+function mockMatchMedia(matches: boolean) {
+  window.matchMedia = jest.fn().mockImplementation((query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  }));
+}
+
+describe("getInitialTheme", () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  test("an explicit localStorage value wins over matchMedia", () => {
+    localStorage.setItem(THEME_STORAGE_KEY, "dark");
+    mockMatchMedia(false); // OS prefers light; stored value must still win
+    expect(getInitialTheme()).toBe("dark");
+  });
+
+  test("falls back to matchMedia when localStorage is empty", () => {
+    mockMatchMedia(true); // OS prefers dark
+    expect(getInitialTheme()).toBe("dark");
+  });
+
+  test("falls back to light when neither localStorage nor matchMedia indicate dark", () => {
+    mockMatchMedia(false);
+    expect(getInitialTheme()).toBe("light");
+  });
+});
+
+describe("setTheme", () => {
+  afterEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute("data-theme");
+  });
+
+  test("persists the choice to localStorage and updates the document dataset", () => {
+    setTheme("dark");
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
+    expect(document.documentElement.dataset.theme).toBe("dark");
+  });
+});

--- a/src/services/theme.service.tsx
+++ b/src/services/theme.service.tsx
@@ -1,0 +1,23 @@
+export type Theme = "light" | "dark";
+
+export const THEME_STORAGE_KEY = "theme";
+
+function prefersDarkColorScheme(): boolean {
+  return (
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches
+  );
+}
+
+export function getInitialTheme(): Theme {
+  const stored = localStorage.getItem(THEME_STORAGE_KEY);
+  if (stored === "light" || stored === "dark") {
+    return stored;
+  }
+  return prefersDarkColorScheme() ? "dark" : "light";
+}
+
+export function setTheme(theme: Theme): void {
+  localStorage.setItem(THEME_STORAGE_KEY, theme);
+  document.documentElement.dataset.theme = theme;
+}

--- a/todo/ux-refresh-dark-mode/ux-refresh-dark-mode.impl.md
+++ b/todo/ux-refresh-dark-mode/ux-refresh-dark-mode.impl.md
@@ -1,0 +1,95 @@
+---
+name: ux-refresh-dark-mode.impl.md
+based-on: 7e8cd82
+---
+
+# ux-refresh-dark-mode — Activity Log
+
+[Plan: todo/ux-refresh-dark-mode/ux-refresh-dark-mode.plan.md] [Branch: d5.ux-refresh-dark-mode]
+
+## Log
+
+- `.claude/dotest.txt` created (`npm test -- --watchAll=false`), Q2 zero-th step.
+- `src/App.test.tsx` — replaced stale "learn react" assertion; mocks `fetchSiteData` (never-resolving promise) and asserts `AppHeader` nav renders (`Goals` link). Avoids real network calls in test env.
+- `npm ci` run — node_modules was absent, installed from `package-lock.json`.
+- `src/services/theme.service.tsx` (new) — `getInitialTheme`, `setTheme`, `THEME_STORAGE_KEY`, `Theme` type. Precedence: localStorage > matchMedia > "light".
+- `src/services/theme.service.test.tsx` (new) — precedence tests (localStorage wins, matchMedia fallback, light default) + `setTheme` persistence test.
+- `src/App.scss:1-70` — expanded `:root` token set (semantic text/border/shadow/link/surface, difficulty tokens aliasing `rgb(var(--bs-*-rgb))`, spacing/radius/transition scales, `--app-body-tint`). Added `:root[data-theme="dark"]` block: Bootstrap `--bs-*-rgb` retint (Q1) + dark values for the new semantic tokens. Original 4 brand tokens (`--app-heading-*`, `--app-content-background-color`) left unoverridden in dark — brand identity preserved verbatim in both themes per Decisions; new `--app-surface-background`/`-alt` tokens are what later phases will wire components to instead.
+- `src/index.scss:7-13` — `background-color: var(--app-body-tint); background-blend-mode: multiply;` added to `body`, per plan's locked mechanism.
+- `src/App.tsx:10-27` — `useLayoutEffect(() => { document.documentElement.dataset.theme = getInitialTheme(); }, [])`, separate from the data-fetch effect — runs synchronously before paint, independent of `isLoaded`.
+- `src/components/appheader.component.tsx` — added `ThemeToggle` (new internal component, not `NavLinkWithTooltip` — that defaults to an anchor with `href=""`, wrong semantics for an action button). Uses `Nav.Link as="button"` + `OverlayTrigger`/`Tooltip` (same pattern as existing nav icons), toggles `faSun`/`faMoon`, calls `setTheme` + local state.
+- `src/components/appheader.component.scss` — `.theme-toggle-button` style nested under `.nav-link`: background reset, hover (heading-hover token), `:focus-visible` outline.
+
+Next: run `/doer:dotest`.
+
+- Ran `.claude/dotest.txt`'s command (`npm test -- --watchAll=false`). Hit two pre-existing/incidental issues while fixing the zero-th step, both root-caused and fixed (not worked around):
+  1. `App.tsx`'s `import Stack from "react-bootstrap/esm/Stack"` broke Jest's transform (`SyntaxError: Cannot use import statement outside a module` — ESM subpath bypasses `react-bootstrap`'s CJS `main` field, ignored by CRA's default `transformIgnorePatterns`). Fixed by switching to `import { Stack } from "react-bootstrap"` (same CJS export, root package already imported that way elsewhere in the file). Pre-existing bug, unrelated to Q2/Phase 0, but blocked the gate — fixed at the import.
+  2. CRA's Jest config sets `resetMocks: true`, which strips a `jest.fn()`'s inline implementation before each test runs. My first `App.test.tsx` draft set the never-resolving-promise mock inside the `jest.mock(...)` factory, which the reset wiped (`fetchSiteData()` returned `undefined`). Fixed by mocking with a bare `jest.fn()` in the factory and calling `.mockReturnValue(new Promise(() => {}))` inside the test body (after the per-test reset).
+  3. `AppHeader`'s `LinkContainer`/`useNavigate` needs Router context — wrapped the test render in `<MemoryRouter>`.
+- `npx tsc --noEmit` — clean, no type errors.
+- `npm start` (BROWSER=none) — compiled clean (1 pre-existing unrelated ESLint warning, `hikedeck.component.tsx:2` unused `Stack` import, not touched this phase). Verified via `curl` that both `--app-body-tint` values (`transparent` / `rgba(20, 24, 28, 0.55)`) are present in the compiled bundle. Server stopped after check.
+- Final gate run: `Test Suites: 2 passed, 2 total / Tests: 5 passed, 5 total`, exit 0.
+
+Next-phase needs: Phase 1 should be aware that `--app-content-background-color`/`--app-heading-*` (the original 4 brand tokens) are intentionally NOT overridden in `:root[data-theme="dark"]` — they resolve identically in both themes. The new `--app-surface-background` / `--app-surface-background-alt` tokens are what Phase 1's card-system rewrite should switch components to for a real dark surface (currently `carddeck`/`parkdeck`/`hikelist`/`hikedeck` still reference the old `--app-content-background-color` var directly and will look unchanged/light-toned in dark mode until Phase 1 repoints them).
+
+- `rdo ux-refresh-dark-mode --done` — no items raised in `.impl.review.md`; closed out. Re-ran `/doer:dotest`: 2 suites / 5 tests passed, exit 0. Plan `## TODO` Phase 0 checked off.
+
+Next: `rplan ux-refresh-dark-mode phase-1` (gate review) before Phase 1 `do`.
+
+# Phase 1
+
+- `rplan ux-refresh-dark-mode phase-1` gate review complete: Q3 resolved (pulled `parkdeck.component.scss:15`/`hikelist.component.scss:15` token swap into Phase 1); plan's Phase 1 section also gained a typography-token fix, base `.card` background-color repoint, and a tightened shadow-visibility acceptance criterion (all direct author fixes, no Q needed).
+
+Next: Starting Phase 1 `do`.
+
+- `src/App.scss:38-51` — added typography token scale (`--app-font-size-sm/base/lg/xl/xxl`, `--app-line-height-base/tight`, `--app-font-weight-bold`), same value both themes, per plan's Phase-1-gate direct edit.
+- `src/App.scss:67-71` — retuned dark `--app-shadow-color` from `rgba(0,0,0,0.6)` to `rgba(0,0,0,0.75)`; a flat low-opacity black was imperceptible against `--app-surface-background` (`#1E2227`). Paired with carddeck's larger blur radius (below) to make elevation actually read.
+- `src/index.scss:1-34` — applied typography scale to `body` (font-size/line-height/color) and added `h1`-`h6` weight/line-height + `h1`/`h2`/`h3` size rules, beyond the prior bare `font-family` reset.
+- `src/components/carddeck.component.scss` — `.card` background-color repointed `--app-content-background-color` → `--app-surface-background` (so it's actually dark-toned in dark mode); added `border-radius: var(--app-radius-md)`; box-shadow reworked from flat `2px 2px 2px 1px` to soft `0 var(--app-space-2) var(--app-space-4) var(--app-shadow-color)` (offset/blur via spacing tokens); added `transition: box-shadow`; added `.card-deck .card:hover` shadow lift (scoped to deck cards only, not the lone AppHeader/error-page card wrappers, since those aren't clickable as a whole unit); swapped remaining hardcoded spacing/font-size values (`.card-deck-header`, `.row` gap, `.col` margin, card-header/footer padding+font-size, card-body font-size) to the new spacing/typography tokens.
+- `src/pages/error.page.tsx:9` — fixed `className="App"` → `className="app loaded"` (matches `App.scss`'s lowercase `.app`/`.loaded` selectors; pre-existing bug, error page now gets the shared shell).
+- `src/components/parkdeck.component.scss:15` — `.dropdown-menu` background-color repointed `--app-content-background-color` → `--app-surface-background` (Q3 swap). No other property in this file touched.
+- `src/components/hikelist.component.scss:15` — `ul.hike-list li` background-color repointed `--app-content-background-color` → `--app-surface-background` (Q3 swap). Lines 19-30 (dead `.hike-difficulty-icon` rules) and list spacing untouched, per Out-of-Scope.
+- `src/components/appheader.component.scss` — moved hover/focus-visible/transition from `.theme-toggle-button`-only to the general `.nav-link` (so Goals/Parks/Hikes/Plans/Facebook/GitHub links get the same states, not just the theme toggle); `.theme-toggle-button` now only carries its unique background/border/cursor resets. `header`'s `margin-top` swapped to `var(--app-space-3)`.
+
+- `rdo ux-refresh-dark-mode --done` — no items raised in `.impl.review.md`; closed out. Re-ran `/doer:dotest`: 2 suites / 5 tests passed, exit 0. Plan `## TODO` Phase 1 checked off.
+
+Next: `rplan ux-refresh-dark-mode phase-2` (gate review) before Phase 2 `do`.
+  - Deviation: left `.nav-link`'s `border-left: 1px solid #999999` hardcoded rather than swapping to `var(--app-border-color)` — that token's low-alpha values (0.15) are tuned for neutral surfaces, not the saturated brand-blue navbar backdrop; swapping risked the divider becoming nearly invisible in both themes. Not part of any acceptance criterion, so left as-is rather than risk a visual regression.
+
+Next: run `/doer:dotest`.
+
+- `npm test -- --watchAll=false` — 2 suites / 5 tests passed, exit 0 (no test changes needed this phase; pure CSS/JSX styling).
+- `npx tsc --noEmit` — clean.
+- `npm start` (BROWSER=none) — compiled clean, no new warnings. Verified via bundle.js: `--app-font-size-xxl: 2rem` present; `--app-shadow-color` resolves to `rgba(0, 0, 0, 0.2)` (light) and `rgba(0, 0, 0, 0.75)` (dark, retuned this phase); `"app loaded"` string present (error page fix compiled in). Server stopped after check.
+
+Next: `rdo ux-refresh-dark-mode --done` (Phase 1 gate review), then `rplan ux-refresh-dark-mode phase-2` before Phase 2 `do`.
+
+- `rdo ux-refresh-dark-mode --done` — no items raised; closed out. Re-ran `/doer:dotest`: 2 suites / 5 tests passed. Plan `## TODO` Phase 1 checked off.
+
+# Phase 2
+
+- `rplan ux-refresh-dark-mode phase-2` gate review complete (retried once after a first attempt hit an API session-limit error mid-task with no files written): Q4 resolved — a real dark-mode text-legibility bug (hike-list rows on Parks/Plans pages, Parks dropdown items, and `.badge-transparent` all render near-invisible) fixed via per-component `color: var(--app-text-primary)` overrides at `hikelist.component.scss:15`, a new `.dropdown-item` rule in `parkdeck.component.scss`, and `utils.component.scss:9`, rather than a Bootstrap-var retint (which would be shadowed by `.list-group`/`.dropdown-menu`'s own local var redeclaration). Phase 2's plan section also gained 3 new locked Acceptance Criteria for this and a corrected Files list.
+
+Next: Starting Phase 2 `do`.
+
+- `rdo ux-refresh-dark-mode --done` — no items raised in `.impl.review.md`; closed out. Re-ran `/doer:dotest`: 2 suites / 5 tests passed, exit 0. Plan `## TODO` Phase 2 checked off — all 3 phases now complete.
+
+Next: `done ux-refresh-dark-mode` to verify and close the plan.
+
+- Human spotted a 4th dark-mode legibility bug during final review (same class as Q4, but not caught by the Phase 2 gate since `App.tsx` wasn't in that phase's file list): the loading `ClimbingBoxLoader` (`App.tsx:45`) hardcoded `color="var(--app-heading-background-color)"` — the brand blue, intentionally un-overridden in dark mode per Phase 0's Decisions — rendering low-contrast against the now-dark, tinted body background.
+- First fix attempt swapped to `var(--app-text-primary)` directly, but human clarified: the blue was fine (good, in fact should) in light mode — matches the card-header color — only dark mode needed to change. Corrected: added a new `--app-spinner-color` token (`App.scss`) — light value `var(--app-heading-background-color)` (brand blue, unchanged), dark value `var(--app-text-primary)` (`#E8E6E3`, the already-approved dark legibility color). `App.tsx:45` now reads `color="var(--app-spinner-color)"`. Re-ran `/doer:dotest`: 2 suites / 5 tests passed, exit 0.
+
+- `src/components/hikelist.component.scss` — deleted dead `.easy-hike`/`.moderate-hike`/`.hard-hike`/`.unknown-hike` `.hike-difficulty-icon` rules (lines 19-30, confirmed unreferenced). Added `color: var(--app-text-primary)` to `ul.hike-list li` (Q4 fix, site 1). Card-adjacent styling: `border-radius: 6px` → `var(--app-radius-sm)`; mechanical em→token swaps on `margin-bottom`/`padding` (equivalent values). Left `.hike-info a.col:hover`'s hardcoded `#cecece75` as-is — no existing token models a neutral hover-tint overlay and this file isn't in scope to add one to `App.scss`; not gated on any acceptance criterion.
+- `src/components/parkdeck.component.scss` — added `.dropdown-item` + `.dropdown-item:hover` under the existing `+ .dropdown-menu` nesting, `color: var(--app-text-primary)` (Q4 fix, site 2), scoped to the Parks dropdown only (not a global `.dropdown-item` rule). Token pass: `#parks-dropdown`'s `font-size: small`/`padding: 0.25em 0.5em` → `var(--app-font-size-sm)`/`var(--app-space-1) var(--app-space-2)`; `.card-deck` `gap: 0.25em` → `var(--app-space-1)`; `.card-footer` `font-size: smaller` → `var(--app-font-size-sm)`. No `.tsx` change needed — `Dropdown.Item` already renders the `.dropdown-item` class Bootstrap-side.
+- `src/components/utils.component.scss` — `.badge-transparent` `color: var(--bs-list-group-color)` → `var(--app-text-primary)` (Q4 fix, site 3). `.badge`'s padding already references Bootstrap's own `--bs-badge-*` vars appropriately; left as-is rather than swapping to the app spacing scale (font-size especially — Bootstrap's default `0.75em` vs our `--app-font-size-sm` `0.875rem` aren't equivalent, risk of a visual-size regression with no acceptance criterion requiring it). No `.tsx` change needed.
+- `src/components/hikedeck.component.scss` — `.card-footer`'s `font-size: unset !important` (stale comment "set to smaller globally") → explicit `var(--app-font-size-sm) !important`, matching the comment's actual intent. Added `padding`/`border-radius`/hover `transition` tokens to `.card-header a:has(svg)` (the map/post icon links) for a card-adjacent hover affordance. No `.tsx` change needed.
+- `src/components/ebrpgoal.component.scss` — added `margin-bottom: var(--app-space-4)` between the three `.ebrp-goal-list` blocks (Completed/In Progress/Not Started), `gap: var(--app-space-2)` on the multi-column `ul`, `margin-bottom: var(--app-space-1)` on `li`. No `.tsx` change needed — purely spacing.
+- Pages (`hikes.page.tsx`, `parks.page.tsx`, `goals.page.tsx`, `plans.page.tsx`/`plans.page.scss`) — read all 4; confirmed thin wrappers with no page-specific styling gaps (`plans.page.scss` still empty). No changes made — nothing needed hanging new classes.
+
+Next: run `/doer:dotest`.
+
+- `npm test -- --watchAll=false` — 2 suites / 5 tests passed, exit 0 (no test changes needed; pure CSS styling this phase).
+- `npx tsc --noEmit` — clean.
+- `npm start` (BROWSER=none) — compiled clean, no new ESLint warnings. Verified via bundle.js source: dead `.hike-difficulty-icon` color rules absent; `ul.hike-list li { ...; color: var(--app-text-primary); ... }` present; `#parks-dropdown + .dropdown-menu .dropdown-item` (+ `:hover`) with `color: var(--app-text-primary)` present; `.badge-transparent { ...; color: var(--app-text-primary); }` present. Server stopped after check.
+
+Next: `rdo ux-refresh-dark-mode --done` (Phase 2 gate review), then `done ux-refresh-dark-mode` to close out the plan.

--- a/todo/ux-refresh-dark-mode/ux-refresh-dark-mode.impl.review.md
+++ b/todo/ux-refresh-dark-mode/ux-refresh-dark-mode.impl.review.md
@@ -1,0 +1,18 @@
+---
+name: ux-refresh-dark-mode.impl.review.md
+author: Human
+reviewer: Agent
+status: reviewed
+---
+
+# Phase 0
+
+No items raised. `rdo ux-refresh-dark-mode --done` closeout, 2026-07-06.
+
+# Phase 1
+
+No items raised. `rdo ux-refresh-dark-mode --done` closeout, 2026-07-06.
+
+# Phase 2
+
+No items raised. `rdo ux-refresh-dark-mode --done` closeout, 2026-07-07.

--- a/todo/ux-refresh-dark-mode/ux-refresh-dark-mode.plan.md
+++ b/todo/ux-refresh-dark-mode/ux-refresh-dark-mode.plan.md
@@ -1,0 +1,170 @@
+---
+status: doing
+based-on: (none — derived fresh from description, no TODO.md item)
+---
+
+# ux-refresh-dark-mode — Modernize the site's visual layer and add dark mode
+
+## Problem / Requirements
+
+davidhikesalot.github.io (React 18 + TS, CRA/react-scripts 5.0.1, react-bootstrap 2.6.0, FontAwesome 7.0.0 via react-fontawesome 0.2.3, SCSS with `sass` 1.58.3, date-fns, react-router-dom 6.30.1) has had no visual-design attention since its original build. The ask ("modernize the UX") was scoped down via inline grilling to a concrete brief:
+
+1. **Visual refresh only, not an IA/feature overhaul.** No navigation restructuring, no new features (search/filter/etc.), no framework or dependency swap. Keep CRA + react-bootstrap + SCSS. This is typography, spacing, elevation/shadow, card/list treatment, hover/focus states, and transitions.
+2. **Scope = every page + shared chrome**, so the whole site reads as one consistent system rather than a per-page patchwork:
+   - Pages: `src/pages/hikes.page.tsx`, `parks.page.tsx`, `goals.page.tsx`, `plans.page.tsx` (+ `plans.page.scss`), `error.page.tsx`.
+   - Shared chrome: `src/components/appheader.component.tsx` (+ `.scss`), `src/layouts/page.layout.tsx`.
+   - Shared card/list components: `carddeck`, `hikedeck`, `parkdeck`, `ebrpgoal`, `hikelist`, `utils` (`.component.tsx` + `.component.scss` pairs).
+   - Root styling: `src/App.scss` (root CSS custom properties, `.app` shell), `src/index.scss` (body font, tiled topo background image).
+3. **Keep brand identity, evolve execution.** Do not propose a new color scheme or drop the current identity — blue heading `#3D6B8F` / hover `#3d6c8f83`, heading text `#D6D4D0`, content background `#D6D4D0` (currently the only 4 CSS custom properties, `src/App.scss:1-6`), and the tiled topo-map background (`src/index.scss:7-11`, `public/assets/img/bg-topo-square.png`). This plan refines the token set (spacing scale, elevation, typography hierarchy, radius, transitions) and card/list treatments around that identity — evolution, not rebrand.
+4. **Dark mode is genuinely in scope** — a real scope addition, not just polish. Confirmed via grep: zero existing `prefers-color-scheme` / `data-theme` handling anywhere in `src/`. Required:
+   - A second (dark) palette derived from/complementary to the existing brand colors.
+   - A toggle, defaulting on first load to `prefers-color-scheme` if no stored preference exists.
+   - Persistence across sessions (localStorage).
+
+**Grounded findings that shape phasing and file list:**
+- All 4 existing brand colors live as CSS custom properties on `:root` in `src/App.scss:1-6` — the natural seam for a token system and for a `data-theme` swap.
+- `carddeck.component.scss` defines the base `.card` / `.card-deck` treatment (border, shadow, header/footer) that `hikedeck`, `parkdeck`, and `hikelist` all build on top of or duplicate (`hikelist.component.scss:14` reimplements a card-like `li` treatment independently rather than reusing `.card`). Any change to the base card system reshapes what the per-component overrides need to do — this is real causal coupling, not just breadth, and is why the plan is phased.
+- **`hikelist.component.scss:19-30`'s `green`/`blue`/`black`/"unknown" difficulty-icon rules are dead CSS.** Verified via `grep -rn "hike-difficulty-icon" src/` — that class is never rendered anywhere; `hikelist.component.tsx`'s `<DifficultyIcon hike={hike} />` renders `utils.component.tsx`'s `DifficultyIcon`, which uses Bootstrap contextual classes (`text-success`/`text-primary`/`text-dark`) instead, with no class named `hike-difficulty-icon`. A straight "swap these 4 colors for tokens" fix would touch zero rendered pixels. The actual difficulty-icon (and favorite-icon, goal-status-icon, badge) colors sitewide come from **Bootstrap's CDN stylesheet** (`public/index.html:53`, `bootstrap@5.2.3`), via `text-success`/`text-primary`/`text-dark`/`text-danger` and `Badge bg="..."` in `utils.component.tsx`, `ebrpgoal.component.tsx` (`parkStatusIcons`), and `hikedeck.component.tsx` (`DifficultyIcon`/`FavoriteIcon` reuse) — none of it routed through this app's `--app-*` token system. Confirmed (fetched the actual CDN bundle) these resolve as `color: rgba(var(--bs-success-rgb), var(--bs-text-opacity))` etc., with `--bs-success-rgb`/`--bs-primary-rgb`/`--bs-dark-rgb`/`--bs-danger-rgb`/`--bs-secondary-rgb` defined once at `:root` — overridable by a same-or-higher-specificity `:root[data-theme="dark"]` rule regardless of stylesheet load order (`:root[data-theme="dark"]` beats bare `:root` on specificity). See `## Q1` — this reshapes Phase 0's mechanism scope and Phase 2's hikelist file entry (moved off the dead selector). Separately: `utils.component.tsx:72`'s `DifficultyIcon` already renders nothing (`?? <></>`) for an unrecognized difficulty — the "unknown" case needs no color token at all; the dead CSS's same-color "hide it" trick was a superseded earlier approach, not live behavior to preserve.
+- `error.page.tsx:9` renders `<div className="App">` (capital A) — `src/App.scss:8` only styles `.app` (lowercase). This is a pre-existing class-name-case bug: the error page never gets the `.app` shell's `max-width`/margin/padding. Since this plan touches `error.page.tsx` anyway, fix it there rather than propagating a redesign onto a broken shell.
+- `plans.page.scss` exists but is empty; `goals.page.tsx`, `parks.page.tsx`, `hikes.page.tsx` have no page-specific SCSS at all — they render shared deck/list components directly. So "the 4 pages" mostly means "verify the shared components read correctly under each page's real data," not separate per-page stylesheets to redesign.
+- `App.tsx:26` already conditionally toggles a `loaded` class based on fetch state — the same component owns the root `.app` div, so it's the natural place to also own `document.documentElement.dataset.theme` initialization and host the theme toggle (via `AppHeader`, which `App.tsx:27` already renders).
+- Services in this repo are plain exported functions in `src/services/*.service.tsx` (see `data.service.tsx`) — no class/singleton/context pattern. The new theme logic should mirror that: a plain `src/services/theme.service.tsx` module, not a new React Context provider, to match the existing idiom and avoid introducing a new pattern for one small piece of state.
+- FontAwesome 7.0.0 free-solid-svg-icons already ships `faSun` / `faMoon` — no new icon dependency needed for the toggle.
+
+## Plan
+
+Three phases. Phase 0 is the foundation everything else depends on (token vocabulary + the dark-mode extension mechanism itself) and must land and be reviewed before any visual-application phase starts, since it fixes the CSS variable names and theming API the later phases write against. Phase 1 and 2 split along the causal-coupling seam identified above: Phase 1 redesigns the base card system + chrome that Phase 2's per-component overrides build on.
+
+### Phase 0: Design tokens + dark-mode mechanism (foundation)
+
+Establish the full token vocabulary and the theme-switching mechanism. No visual redesign of any page/component yet beyond what's needed to prove the mechanism works — that's Phases 1-2.
+
+**(Q2, resolved) Zero-th step, before any Phase 0 code:** `.claude/dotest.txt` is absent, which hard-fails the `/doer:dotest` gate at every phase boundary (doer rule 10). Separately, `src/App.test.tsx` is stale CRA boilerplate (`screen.getByText(/learn react/i)`) that already fails today, unrelated to this plan — confirmed via `grep -rn "learn react" src public` that no such text exists anywhere in the app. Fix both before writing any Phase 0 code: create `.claude/dotest.txt` with `npm test -- --watchAll=false`, and fix/remove `App.test.tsx` (replace its assertion with something real, e.g. asserting `AppHeader` renders, or delete the file) so the gate isn't permanently broken by an unrelated pre-existing failure — this matters because Phase 0 adds a real test (`theme.service.test.tsx`) that needs the gate to actually run.
+
+**Extension mechanism (named explicitly per plan.md's rule — this is the load-bearing structural decision):**
+- CSS custom properties remain the mechanism (matches existing `App.scss:1-6` idiom). Expand the token set on `:root` in `src/App.scss` to cover: brand colors (existing 4, kept as-is for light), a full semantic layer (text-primary/secondary, border, shadow-color, link, surface/background layers, difficulty-easy/moderate/hard — no "unknown" token needed, see Problem/Requirements finding above), a spacing scale (e.g. `--space-1` through `--space-5`), a radius scale, and transition duration/easing tokens.
+- **(Q1, resolved) Global retint:** this phase's `:root[data-theme="dark"]` block also overrides Bootstrap's CDN-loaded contextual utility colors — `--bs-success-rgb`/`--bs-primary-rgb`/`--bs-dark-rgb`/`--bs-danger-rgb`/`--bs-secondary-rgb` — so `text-success`/`text-dark`/etc. (difficulty icons, favorite icon, goal-status icons, badges — see Problem/Requirements) go dark-safe sitewide with zero component-file changes. `react-bootstrap` stays as the styling library (a stack swap to Tailwind or similar was considered and explicitly deferred to a possible future separate plan — out of scope here).
+- Dark values live in a `:root[data-theme="dark"]` override block (same file, directly below the light `:root` block) — only the tokens whose dark value differs need overriding; unset ones inherit the light value.
+- `document.documentElement.dataset.theme` is the runtime switch. Set once on load, updated on toggle. No CSS-in-JS, no new state-management library.
+- `src/services/theme.service.tsx` (new, mirrors `data.service.tsx`'s plain-function style) exports:
+  - `getInitialTheme(): "light" | "dark"` — resolution order: `localStorage.getItem(THEME_STORAGE_KEY)` if present and valid, else `window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"`, else `"light"`.
+  - `setTheme(theme)` — writes `localStorage`, sets `document.documentElement.dataset.theme`.
+  - `THEME_STORAGE_KEY` constant.
+- `App.tsx` calls `getInitialTheme()` once (e.g. alongside the existing `useEffect` that fetches site data) and applies it before/without waiting on the data fetch, so there's no flash of the wrong theme while `isLoaded` is false.
+- A `ThemeToggle` UI lives in `AppHeader` (`appheader.component.tsx`, in the existing right-hand `<Nav>` alongside the Facebook/GitHub `NavLinkWithTooltip` icons) — a button using `faSun`/`faMoon` that calls `setTheme` and re-renders its own icon from current theme state.
+- `src/index.scss`'s tiled topo background (`index.scss:7-11`) needs a dark-mode-aware treatment decided here (not deferred) since it's the single most visible cross-theme surface: keep the same tiled PNG, apply a themed tint via a `background-color` + `background-blend-mode` pairing driven by a new `--app-body-tint` token, rather than inverting/filtering the image (filter/invert risks an ugly, unreadable result). Concrete starting recipe (tune the exact numbers visually during `npm start`, per this phase's Verify step — not an open fork, just a tuning pass): `background-color: var(--app-body-tint); background-blend-mode: multiply;` with `--app-body-tint: transparent` in light (no change from today) and `--app-body-tint: rgba(20, 24, 28, 0.55)` in dark (multiply always darkens, so one blend mode covers both directions — only the tint color/opacity needs adjusting per theme). The mechanism (token-driven blend layer, same image asset) is the locked decision; only the tint's exact rgba value is a visual-tuning knob, checked against this phase's own acceptance criterion ("Body's topo background remains visible... in both themes").
+
+**Files:**
+- `.claude/dotest.txt` (new) — `npm test -- --watchAll=false` (zero-th step, Q2).
+- `src/App.test.tsx` — fix or remove the stale `"learn react"` assertion (zero-th step, Q2).
+- `src/App.scss:1-6` — expand `:root` token set; add `:root[data-theme="dark"]` override block, including the `--bs-success-rgb`/`--bs-primary-rgb`/`--bs-dark-rgb`/`--bs-danger-rgb`/`--bs-secondary-rgb` retint (Q1).
+- `src/index.scss:1-12` — dark-aware body background treatment using new tint token.
+- `src/services/theme.service.tsx` (new) — `getInitialTheme`, `setTheme`, `THEME_STORAGE_KEY`.
+- `src/App.tsx:10-22` — call `getInitialTheme()`/apply theme on mount.
+- `src/components/appheader.component.tsx` — add `ThemeToggle` button (faSun/faMoon) to the right-hand `<Nav>`.
+- `src/components/appheader.component.scss` — style the toggle button (hover/focus state, sizing consistent with existing nav icons).
+
+**Acceptance Criteria:**
+- [ ] `/doer:dotest` gate passes (not hard-failing on a missing `.claude/dotest.txt` or the stale `App.test.tsx`).
+- [ ] Loading the site with no prior localStorage value and OS set to dark renders in dark theme; OS set to light renders in light theme.
+- [ ] Toggling the theme updates `document.documentElement.dataset.theme` immediately and persists across a full page reload (localStorage).
+- [ ] All 4 original brand-color tokens still resolve to their current light-mode hex values — no accidental rebrand.
+- [ ] No flash of unthemed content: theme is applied before the loading spinner / first paint of content, not after `isLoaded` flips.
+- [ ] Body's topo background remains visible (not fully obscured or inverted-to-noise) in both themes.
+- [ ] Bootstrap contextual classes (`text-success`/`text-primary`/`text-dark`/`text-danger`, `Badge bg="..."`) render dark-safe automatically in dark mode via the `--bs-*-rgb` retint, with no per-component changes.
+
+**Verify:** `npm start`, toggle OS appearance + the in-app toggle, confirm via devtools that `--app-*` custom properties resolve to the expected dark/light values in each state; reload and confirm persistence.
+
+**Tests:**
+- `src/services/theme.service.test.tsx` (new) — `getInitialTheme()` resolution order: explicit localStorage value wins over `matchMedia`; falls back to `matchMedia` when localStorage is empty; falls back to `"light"` when neither is available. Mock `window.matchMedia` and `localStorage` per case — don't just assert one happy path, assert the *precedence* (a test that passes whether or not localStorage is actually consulted first is not a good test here).
+
+### Phase 1: Shared chrome + base card system
+
+Apply the Phase 0 tokens to the site shell and the base `.card`/`.card-deck` system everything else extends. Fix the `error.page.tsx` class-case bug while it's being touched for the redesign.
+
+**Files:**
+- `src/App.scss` — `.app` shell spacing/max-width using new spacing tokens. **Also adds a typography token scale to `:root`** (e.g. `--app-font-size-sm/base/lg/xl/xxl`, `--app-line-height-base/tight`, `--app-font-weight-bold`) — Phase 0 didn't create one (confirmed: no `--app-font-*`/`--app-line-height-*` tokens exist in the shipped `App.scss`), but `index.scss`'s typography pass (below) needs tokens to apply; mirror the existing `--app-space-*` scale's granularity; same value in both themes (typography isn't theme-dependent, no dark override needed).
+- `src/index.scss` — typography scale (font sizes/weights/line-height) beyond the current bare `font-family` reset, using the tokens added above.
+- `src/components/appheader.component.scss` / `.tsx` — nav hover/focus states, transitions, spacing using new tokens.
+- `src/components/carddeck.component.scss` — card elevation (replace the flat `box-shadow: 2px 2px 2px 1px rgba(0,0,0,0.2)` with token-driven elevation that has a sane dark-mode equivalent — a flat black shadow disappears on a dark surface), border-radius, hover/transition states, using the new token set. **Also repoint `.card`'s `background-color`** from `--app-content-background-color` to `--app-surface-background` (`carddeck.component.scss:49`) — the former is intentionally left un-overridden in `:root[data-theme="dark"]` per Phase 0's Decisions (brand identity preserved verbatim), so without this swap `.card` stays light-toned (`#D6D4D0`) in dark mode regardless of the elevation work.
+- `src/pages/error.page.tsx` — fix `className="App"` → `className="app loaded"` (matches `App.scss:8`'s `.app` + `.loaded` selector) so the error page gets the same shell and reads as part of the same system; apply the refreshed card treatment to its content.
+- `src/components/parkdeck.component.scss:15` — (Q3) repoint `.dropdown-menu` `background-color` from `--app-content-background-color` to `--app-surface-background`, same rationale as the `.card` swap above. Everything else in this file (dropdown polish beyond this one property) stays Phase 2.
+- `src/components/hikelist.component.scss:15` — (Q3) repoint the live `ul.hike-list li` `background-color` from `--app-content-background-color` to `--app-surface-background`. The dead `.hike-difficulty-icon` color rules (lines 19-30) stay Phase 2 (deletion), and list spacing/layout stays Phase 2.
+
+**Out of Scope:** `hikedeck`, `ebrpgoal`, `utils` component styling; all of `parkdeck`/`hikelist` beyond the single `background-color` swaps above (dropdown polish, list spacing, dead-CSS deletion stay Phase 2).
+
+**Acceptance Criteria:**
+- [ ] `.card` / `.card-header` / `.card-footer` render with refreshed elevation, radius, and spacing in both themes; box-shadow is *actually visible* (not merely present in the DOM) against the dark `--app-surface-background` (`#1E2227`) — a black shadow can read as invisible against an already-dark surface. If the shipped dark `--app-shadow-color` doesn't read, retune its value in `App.scss` (already in this phase's file scope) rather than treating "token exists" as done; border may need to carry more of the elevation cue in dark mode.
+- [ ] Body text and headings use the new typographic scale (visible font-size/weight hierarchy, not just the bare `font-family` reset) — check at least one heading + body-copy pairing.
+- [ ] Nav links in `AppHeader` have visible hover and keyboard-focus states (not just `:hover`), in both themes.
+- [ ] `error.page.tsx` renders inside the same `.app` shell (constrained width, correct margin/padding) as every other page, in both themes.
+
+**Verify:** `npm start`; visually inspect `AppHeader` and any one card-bearing page in both themes — confirm card elevation is *perceptible* against the dark surface (retune `--app-shadow-color` if not) and that heading/body typography reads as a scale; navigate to a broken route (or temporarily throw) to inspect `error.page.tsx` inside the shell.
+
+### Phase 2: Per-component and per-page pass
+
+Apply the Phase 1 card system + Phase 0 tokens to the deck/list components and confirm each of the 4 route pages reads correctly with real data. Delete `hikelist.component.scss`'s dead difficulty-color CSS. Difficulty/favorite/goal-status icon colors (Bootstrap `text-success`/`text-primary`/`text-dark`/`text-danger` utility classes) are dark-safe from Phase 0's global `--bs-*-rgb` retint (Q1) — no work needed there.
+
+**(Phase 2 gate, direct edit — not a Q) Correction to the above:** Q1's retint does NOT cover every Bootstrap-component color. Confirmed via the fetched Bootstrap 5.2.3 bundle (`public/index.html:53`): `--bs-list-group-color`/`--bs-list-group-bg` and `--bs-dropdown-link-color`/`--bs-dropdown-color`/`--bs-dropdown-bg` are redeclared directly on `.list-group`/`.dropdown-menu` themselves (component-local, not just `:root`-default) — unlike Q1's five `-rgb` vars, which are declared exactly once, at `:root`, with zero component-level redeclaration (that's why Q1's flat `:root[data-theme="dark"]` retint worked cleanly for those). A same-shaped extension of Q1's retint list would be shadowed by the component's own local declaration and silently no-op. This left 3 concrete, screenshot-confirmed (headless Chromium + human's own browser) dark-mode legibility bugs unaddressed:
+- Hike-list item text (name/park name + distance/elevation stats) in both the Parks page's embedded `HikeList` and the Plans page's `HikeListCard` (`src/pages/plans.page.tsx:14`) — `hikelist.component.scss:15`'s Phase-1 `background-color: var(--app-surface-background)` swap on `ul.hike-list li` never got a matching `color` override, so text still resolves to Bootstrap's un-retinted `.list-group`-scoped `--bs-list-group-color` (`#212529`) — near-invisible against the now-dark surface.
+- Parks dropdown item text (`parkdeck.component.scss`'s `.dropdown-item`s, rendered via `Dropdown.Item` in `parkdeck.component.tsx:147-161`) — same `.dropdown-menu`-local-shadow pattern; the dropdown container's background was already swapped to `--app-surface-background` in Phase 1, but item text color was not addressed.
+- `DistanceBadge`/`ElevationBadge`'s `.badge-transparent` class (`utils.component.scss:9`) explicitly reads the same un-retinted `--bs-list-group-color`.
+
+**(Q4, resolved) Fix mechanism:** per-component `color: var(--app-text-primary)` overrides at all 3 read sites (not a `:root` Bootstrap-var retint — `.list-group`/`.dropdown-menu` redeclare their color vars locally on themselves, which would shadow and silently no-op a Q1-style retint, and that approach still couldn't reach the `.badge-transparent` site regardless). Same per-component-override pattern Q3 already established once a Bootstrap var stops being a clean single-`:root`-declaration case. The legibility requirement itself is locked below as an Acceptance Criterion, not left implicit.
+
+**Files:**
+- `src/components/hikedeck.component.scss` / `.tsx` — apply refreshed card system; spacing/typography pass.
+- `src/components/parkdeck.component.scss` / `.tsx` — dropdown styling using new tokens; card system; fix `.dropdown-item` text-color bug (Q4).
+- `src/components/ebrpgoal.component.scss` / `.tsx` — list/column spacing pass.
+- `src/components/hikelist.component.scss` — delete the dead `.easy-hike .hike-difficulty-icon` / `.moderate-hike` / `.hard-hike` / `.unknown-hike` rules (`hikelist.component.scss:19-30`, confirmed unreferenced — see Problem/Requirements finding); apply card-adjacent styling (radius, border) consistent with Phase 1's card system to `ul.hike-list li` instead; fix `ul.hike-list li` text-color bug (Q4) — the existing `background-color` swap (`hikelist.component.scss:15`) needs a matching `color` fix. While touching this file, also consider retiring `.hike-info a.col:hover`'s hardcoded `#cecece75` in favor of a token (mechanical, not gated on — see Verify).
+- `src/components/utils.component.scss` / `.tsx` — badge styling pass using new tokens (spacing/sizing only); fix `.badge-transparent`'s (`utils.component.scss:9`) text-color bug per Q4 — difficulty/favorite/goal-status colors elsewhere in this file are unaffected (already dark-safe via Q1).
+- `src/pages/hikes.page.tsx`, `parks.page.tsx`, `goals.page.tsx`, `plans.page.tsx` (+ `plans.page.scss`) — no expected structural changes (they're thin wrappers over the components above); verify each renders correctly under the new system with real fetched data, add page-level SCSS only if something doesn't fall out of the component-level changes.
+
+**Acceptance Criteria:**
+- [ ] Hike difficulty icons (easy/moderate/hard — "unknown" renders no icon at all, `utils.component.tsx:72`, so nothing to check there) are legible with sufficient contrast in both light and dark themes.
+- [ ] `HikeDeck`, `ParkDeck`, `EastBayChallengePage` (goals), and `HikeListCard` (plans) all render using the Phase 1 card system with no visual regressions against real fetched data.
+- [ ] **(New — closes a gap Phase 0/1 left open; screenshot-confirmed regression.)** Hike-list item text — hike name, park name, and distance/elevation stats (`hikelist.component.scss`/`hikelist.component.tsx`, both the Parks page's embedded `HikeList` and the Plans page's `HikeListCard`) — is legible (sufficient contrast) against the dark surface background in dark mode.
+- [ ] Parks dropdown (`parkdeck.component.scss:5-23`) — both the container background AND each dropdown item's text — is legible and themed correctly in dark mode.
+- [ ] Badges (`utils.component.scss`), including `DistanceBadge`/`ElevationBadge`'s `.badge-transparent` variant, read correctly (visible text against their background) in both themes.
+
+**Out of Scope:** any change to data-fetching, routing, or page composition — pages only get styling/token changes, no structural/JSX-logic changes beyond what's needed to hang the new classes.
+
+**Verify:** `npm start`; visit `/hikes`, `/parks`, `/goals`, `/plans` in both themes with real data; toggle theme on each — specifically check hike-list row text (Parks + Plans pages) and Parks dropdown item text against the dark surface, not just container backgrounds (the two areas Phase 0/1 missed).
+
+## Files
+(See per-phase `**Files:**` above — phase-scoped since this is a phased plan.)
+
+## Acceptance Criteria
+(See per-phase `**Acceptance Criteria:**` above.)
+
+## Verify
+(See per-phase `**Verify:**` above. No automated visual-regression tooling exists in this repo (CRA/react-scripts, no Storybook/Percy/Chromatic) — verification is manual (`npm start`) plus the Phase 0 unit test for theme resolution logic.)
+
+## Tests
+- `src/services/theme.service.test.tsx` (new, Phase 0) — see Phase 0 acceptance criteria above for the precedence cases required.
+- No other new automated tests planned — remaining phases are CSS/JSX styling changes without new business logic; existing `react-scripts test` / testing-library setup stays as-is. If `rplan` determines specific interaction logic (e.g. the toggle's click handler) warrants a component test, add it at that gate.
+
+## Out of Scope
+- IA/navigation restructuring, new features (search, filtering, etc.), CRA/react-bootstrap/SCSS migration to any other stack.
+- New UI component libraries — react-bootstrap 2.6.0 stays; no new dependency for theming beyond the plain `theme.service.tsx` module.
+- Automated visual-regression tooling setup (out of scope for this pass; manual verification only).
+
+## TODO
+- [x] Phase 0: Design tokens + dark-mode mechanism
+- [x] Phase 1: Shared chrome + base card system
+- [x] Phase 2: Per-component and per-page pass
+
+## Decisions
+- `hikelist.component.scss:19-30`'s difficulty-icon color rules are dead CSS (target a class never rendered) — deleted in Phase 2 rather than "token-ified"; the live rendering path is Bootstrap-utility-class-driven (`utils.component.tsx`, `ebrpgoal.component.tsx`). (Author, rplan initial pass — grep-verified, not a judgment call.)
+- No `--app-difficulty-unknown` token needed — `utils.component.tsx:72`'s `DifficultyIcon` already renders nothing for an unrecognized difficulty. (Author, rplan initial pass.)
+- Topo-background dark tint: `background-blend-mode: multiply` with a `--app-body-tint` token (`transparent` light / `rgba(20,24,28,0.55)` dark starting point) — mechanism locked, exact rgba is a visual-tuning knob checked at Phase 0's Verify step, not a fork. (Author, rplan initial pass.)
+- (Q1) Retint Bootstrap's CDN contextual colors (`--bs-success-rgb`/`--bs-primary-rgb`/`--bs-dark-rgb`/`--bs-danger-rgb`/`--bs-secondary-rgb`) globally in Phase 0's `:root[data-theme="dark"]` block, rather than per-component in Phase 2 — cheaper (one file), and every current Bootstrap-contextual-color usage in this repo is one of the things this plan already wants dark-safe. `react-bootstrap` stays as the styling library; a stack swap (e.g. to Tailwind) was raised and explicitly deferred to a possible future separate plan.
+- (Q2) Create `.claude/dotest.txt` (`npm test -- --watchAll=false`) and fix/remove the stale `App.test.tsx` as a zero-th step of Phase 0, rather than an empty no-op opt-out — Phase 0 adds a real test (`theme.service.test.tsx`) that needs the gate to actually run.
+- (Q3) Pull `parkdeck.component.scss:15` and `hikelist.component.scss:15`'s `--app-content-background-color` → `--app-surface-background` swap into Phase 1 (alongside the already-Phase-1 `carddeck.component.scss:49` swap), rather than leaving them in Phase 2 — 2-line mechanical change, and it removes a false-negative signal from Phase 1's own dark-mode Verify step.
+- (Q4) Fix the un-retintable `.list-group`/`.dropdown-menu`/`.badge-transparent` text-color bug (hike-list rows, Parks dropdown items, distance/elevation badges all render near-invisible in dark mode) via per-component `color: var(--app-text-primary)` overrides at the 3 read sites, rather than a scoped Bootstrap-var retint — the retint approach would be shadowed by Bootstrap's own component-local var redeclaration and couldn't reach the badge case anyway; matches the precedent Q3 set.
+- (Phase 1 gate, direct edit — not a Q) Phase 1's `index.scss` typography-scale bullet referenced "new tokens" that don't exist — Phase 0's actual token set (verified against shipped `App.scss`) has spacing/radius/transition/semantic-color tokens but no font-size/line-height/weight scale. Added typography token creation to Phase 1's `App.scss` bullet rather than opening a Q — no design fork, just a plan omission (Phase 0 never asked for these either), same latitude as the existing `--app-space-*` scale's non-prescriptive `e.g.` values.
+- (Phase 1 gate, direct edit — not a Q) Phase 1's `carddeck.component.scss` bullet didn't call out the `.card` `background-color` token swap (`--app-content-background-color` → `--app-surface-background`) even though it's the base card system Phase 1 already owns and the old var is intentionally un-overridden in dark (Phase 0 Decisions) — without the swap `.card` silently stays light-toned in dark mode. Added explicitly; not a fork, it's required for Phase 1's own "legible in both themes" acceptance bar to be satisfiable at all.
+- (Phase 1 gate, direct edit — not a Q) Tightened Phase 1's shadow/border AC + Verify to explicitly require the box-shadow be *visually perceptible* against the dark surface (not just present as a CSS value) and name `--app-shadow-color` retuning as the fallback if not — same "concrete value, tune visually" pattern Phase 0 established for `--app-body-tint`, not a new fork.
+
+## Status
+`doing` — Phase 0 in progress on branch `d5.ux-refresh-dark-mode`.

--- a/todo/ux-refresh-dark-mode/ux-refresh-dark-mode.plan.review.md
+++ b/todo/ux-refresh-dark-mode/ux-refresh-dark-mode.plan.review.md
@@ -1,0 +1,71 @@
+---
+author: Agent
+reviewer: Human
+status: open
+---
+
+# Phase 0
+
+## Q1: Retint Bootstrap's CDN contextual colors globally, or fix icon/badge colors per-component? [Open]
+
+**Grounding:** `text-success`/`text-primary`/`text-dark`/`text-danger` and `Badge bg="..."` drive every difficulty icon (`utils.component.tsx:66-73` `DifficultyIcon`), the favorite icon (`utils.component.tsx:75-77`), goal-status icons (`ebrpgoal.component.tsx:11-18` `parkStatusIcons`), and stat badges (`utils.component.tsx:83-111`) — none of it routed through this app's `--app-*` tokens. These classes come from Bootstrap 5.2.3 loaded via CDN (`public/index.html:53`), not this repo's Sass. Fetched the actual CDN bundle: `.text-success{color:rgba(var(--bs-success-rgb),var(--bs-text-opacity))}` etc., with `--bs-success-rgb`/`--bs-primary-rgb`/`--bs-dark-rgb`/`--bs-danger-rgb`/`--bs-secondary-rgb` defined once at `:root`. A `:root[data-theme="dark"]` override (attribute selector, higher specificity than bare `:root`) can retint all of them at once regardless of stylesheet load order — the app already leans on a Bootstrap CSS var elsewhere (`utils.component.scss:9` `var(--bs-list-group-color)`), so this isn't a new pattern. Without *some* fix here, Phase 2's own acceptance criteria ("difficulty icons legible... in both themes", "badges read correctly in both themes") can't pass, since `text-dark` in particular (near-black) is what a hard-difficulty icon and a `not-started` goal icon render in today, and it won't move in dark mode under Phase 0's current token-only mechanism.
+
+**Author-1:** Two shapes for the actual fix, both compatible with Phase 0's CSS-custom-property mechanism:
+
+- (a) **Global retint** — add a `--bs-*-rgb` override section to Phase 0's `:root[data-theme="dark"]` block (5 vars: success/primary/dark/danger/secondary). Zero component-file changes; fixes difficulty icons, favorite icon, goal-status icons, and badges in one place. Downside: retints *any* Bootstrap-contextual-colored element sitewide, not just the ones this plan is auditing — if some other `text-primary`/`bg-danger` usage exists (or gets added later) expecting Bootstrap's stock colors, it silently inherits the app's dark palette too.
+- (b) **Per-component** — in Phase 2, swap `DifficultyIcon`/`FavoriteIcon`/`parkStatusIcons`/badges off Bootstrap contextual classes onto new `--app-difficulty-*`/`--app-favorite`/etc. tokens (inline `style` or new component-scoped classes). Scoped, on-brand, but touches render logic (not just CSS) in 3 files (`utils.component.tsx`, `ebrpgoal.component.tsx`, `hikedeck.component.tsx` reuses `DifficultyIcon`/`FavoriteIcon` so no extra edit there) and is more work for a visual-refresh-only plan.
+
+Leaning **(a)** — cheaper, single-file (`App.scss`), and every current Bootstrap-contextual-color usage in this repo *is* one of the four things this plan already wants dark-safe (difficulty/favorite/goal-status/badges); there's no known usage today that needs Bootstrap's stock colors preserved, so the "sitewide" downside is theoretical, not observed.
+
+**Reviewer-1:** Initial answer raised dropping `react-bootstrap` for Tailwind or similar — out of scope for this plan (visual refresh only, per the original `plan` scoping decision). Confirmed: stick with `react-bootstrap`. For this Q specifically, go with (a).
+
+**Resolved.** Global retint — override `--bs-success-rgb`/`--bs-primary-rgb`/`--bs-dark-rgb`/`--bs-danger-rgb`/`--bs-secondary-rgb` in Phase 0's `:root[data-theme="dark"]` block in `App.scss`. No component-file changes; `react-bootstrap` stays as the styling library (a stack swap to Tailwind/etc. is out of scope, candidate for a future separate plan).
+
+## Q2: `.claude/dotest.txt` is absent (hard-fails every phase gate) and `App.test.tsx` is stale CRA boilerplate that will fail on its own — resolve before Phase 0 `do`? [Open]
+
+**Grounding:** doer's universal rule 10: `/doer:dotest` runs at every phase boundary; an absent `.claude/dotest.txt` is a HARD FAIL (only an *empty* file opts out cleanly). `find /Users/davfive/code/davidhikesalot/.claude` shows no `dotest.txt`. Separately, `src/App.test.tsx` is un-updated CRA boilerplate: `screen.getByText(/learn react/i)` — confirmed via `grep -rn "learn react" src public` that no such text exists anywhere in this app, so this test fails today, independent of this plan. Phase 0 also adds a real new test (`theme.service.test.tsx`) that should actually gate.
+
+**Author-1:** Not a design fork, but blocks `do` mechanically — needs a decision before Phase 0 execution starts:
+
+- (a) Create `.claude/dotest.txt` with `npm test -- --watchAll=false` **and** fix/remove the stale `App.test.tsx` as a zero-th step of Phase 0 (small, unrelated-to-redesign cleanup, but otherwise the gate fails on an unrelated pre-existing test forever).
+- (b) Create `.claude/dotest.txt` empty (no-op opt-out) for this plan, leaving the stale test and the gate question for later/another task.
+
+Leaning **(a)** — the plan is about to add a test that matters (`theme.service.test.tsx`'s precedence assertions); a gate that's a permanent no-op would silently mean that test never actually runs. The `App.test.tsx` fix is a one-line change (either delete the file or replace the assertion with something real like the header rendering), not scope creep worth its own phase.
+
+**Reviewer-1:** Agreed, fix both now.
+
+**Resolved.** Create `.claude/dotest.txt` (`npm test -- --watchAll=false`) and fix/remove the stale `App.test.tsx` as a zero-th step of Phase 0.
+
+# Phase 1 [Reviewed]
+
+## Q3: Pull `parkdeck`/`hikelist`'s `--app-content-background-color` token swap into Phase 1, or leave in Phase 2 as originally scoped? [Open]
+
+**Grounding:** `carddeck.component.scss:49`'s base `.card` rule and two component-specific rules — `parkdeck.component.scss:15` (`.dropdown-menu` background under `#parks-dropdown`) and `hikelist.component.scss:15` (`ul.hike-list li` background, the live rule — distinct from the dead `.hike-difficulty-icon` block at lines 19-30 already slated for Phase 2 deletion) — all currently read `background-color: var(--app-content-background-color)`. That token is intentionally left un-overridden in `:root[data-theme="dark"]` (Phase 0 Decisions, brand identity preserved), so it stays `#D6D4D0` (light) in both themes. This plan-review pass already pulled the `carddeck.component.scss:49` swap (`--app-content-background-color` → `--app-surface-background`) into Phase 1 directly (base `.card` is squarely Phase 1's file), but `parkdeck`/`hikelist` are Phase 2's, per Phase 1's `**Out of Scope:**` line. `hikedeck.component.scss` has no reference to this var (confirmed, grep) — moot for that file. Phase 1's own Verify step already visits "any one card-bearing page in both themes" — if that page is Parks or a hike-list view, the reviewer would see the newly-dark `.card` sitting next to a still-light dropdown-menu or `li` background during Phase 1's own gate check.
+
+**Author-1:** Both lines are single-property swaps, not a styling/layout pass (the rest of Phase 2's work on these two files — dropdown polish, list spacing — is unaffected either way):
+
+- (a) **Pull the 2 lines into Phase 1** (`parkdeck.component.scss:15`, `hikelist.component.scss:15`) — Phase 1's own dark-mode Verify pass reads clean on whichever page it happens to hit; Phase 2's `**Out of Scope:**`/file-list still holds for everything else in those files.
+- (b) **Leave both in Phase 2** as originally scoped — matches the plan's stated causal-coupling seam ("Phase 1 = base card system, Phase 2 = per-component overrides") exactly; accept that Phase 1's Verify may surface a visibly inconsistent page and the reviewer needs to know that's expected/incomplete until Phase 2, not a regression.
+
+Leaning **(a)** — it's a 2-line, mechanical, zero-design-judgment change (same token rename `carddeck.component.scss:49` is already getting), and it removes a confusing false-negative signal from Phase 1's own Verify step rather than requiring the human reviewer to remember which components are "not yet touched."
+
+**Reviewer-1:** Agreed, pull into Phase 1.
+
+**Resolved.** Pull `parkdeck.component.scss:15` and `hikelist.component.scss:15`'s `--app-content-background-color` → `--app-surface-background` swap into Phase 1, alongside the already-planned `carddeck.component.scss:49` swap. Phase 2's file-list/out-of-scope for everything else in those two files (dropdown polish, list spacing, dead-CSS deletion) is unchanged.
+
+# Phase 2 [Reviewed]
+
+## Q4: Fix the un-retintable list-group/dropdown/badge text-color bug via scoped Bootstrap-var retint, or per-component `color` overrides? [Open]
+
+**Grounding:** Screenshot-confirmed (headless Chromium + human's own browser) that hike-list row text (name/park/stats, both Parks-page `HikeList` and Plans-page `HikeListCard` — `src/pages/plans.page.tsx:14`) renders near-invisible dark-gray-on-near-black in dark mode. Root cause, confirmed by fetching the actual Bootstrap 5.2.3 CDN bundle (`public/index.html:53`): `.list-group { --bs-list-group-color: #212529; --bs-list-group-bg: #fff; ... }` and `.dropdown-menu { --bs-dropdown-link-color: #212529; --bs-dropdown-color: #212529; --bs-dropdown-bg: #fff; ... }` redeclare these vars *locally on the component's own root class*, not just as `:root` defaults. `hikelist.component.tsx:21`'s `<ListGroup as="ul" className="hike-list">` still carries Bootstrap's own `.list-group` class alongside `.hike-list`, so `hikelist.component.scss:15`'s `background-color: var(--app-surface-background)` swap (Phase 1) only ever touched the background — `.list-group-item`'s `color: var(--bs-list-group-color)` was never addressed and still resolves to `#212529`. This is structurally different from Q1's five `--bs-*-rgb` vars, confirmed (grep) to be declared *exactly once*, at `:root`, with **no** component-level redeclaration anywhere in the bundle — which is why Q1's flat `:root[data-theme="dark"]` retint worked. Extending that same retint-at-`:root` pattern to `--bs-list-group-color`/`--bs-dropdown-link-color` would be shadowed by `.list-group`/`.dropdown-menu`'s own local declaration and silently no-op — a naive "just add more vars to Q1's list" fix does not work here. Same root var also read directly at a third site, `utils.component.scss:9`'s `.badge-transparent { color: var(--bs-list-group-color) }` (used by `DistanceBadge`/`ElevationBadge`, e.g. in `HikeDeck` cards) — outside any `.list-group`/`.dropdown-menu` ancestor there, so currently undefined at that call site (falls back to inherited color rather than rendering broken, but fragile/accidental, not a designed fix).
+
+**Author-1:** Two shapes, both compatible with the existing token mechanism:
+
+- (a) **Scoped Bootstrap-var retint** — add `:root[data-theme="dark"] .list-group, :root[data-theme="dark"] .dropdown-menu { --bs-list-group-color: ...; --bs-list-group-bg: ...; --bs-dropdown-link-color: ...; --bs-dropdown-color: ...; --bs-dropdown-bg: ...; }` to Phase 0's dark block in `App.scss`. Keeps the "one retint block, zero component-file color changes" shape Q1 established for these two sites — but requires correctly enumerating every Bootstrap component class with this local-redeclaration shadow (verified here for `.list-group`/`.dropdown-menu`; a different Bootstrap component reached for later could have the same trap and go unnoticed), and does **not** reach `utils.component.scss:9`'s `.badge-transparent` case at all (outside any `.list-group`/`.dropdown-menu` ancestor, so the scoped selector can't touch it — that site needs its own fix regardless of which option is chosen here).
+- (b) **Per-component direct `color` overrides** — set `color: var(--app-text-primary)` at the 3 actual read sites, all already in Phase 2's file scope: `hikelist.component.scss:15` (alongside the existing `background-color` swap), a new `.dropdown-item`/`.dropdown-item:hover` rule in `parkdeck.component.scss`, and swap `utils.component.scss:9`'s `.badge-transparent` color from `var(--bs-list-group-color)` to `var(--app-text-primary)`. Same shape as Phase 1's Q3 resolution (direct property override beats var-retinting once a Bootstrap var turns out to be component-shadowed or context-dependent); fixes all 3 read sites uniformly, including the one (a) can't reach.
+
+Leaning **(b)** — it's the only option that actually fixes all 3 confirmed/suspect read sites, doesn't require correctly enumerating every Bootstrap component's internal var-shadowing behavior to trust the fix is complete, and matches the precedent Q3 already set (per-component override over var-retint) once a Bootstrap var stops being a clean single-`:root`-declaration case like Q1's.
+
+**Reviewer-1:** Agreed, go with (b).
+
+**Resolved.** Per-component `color: var(--app-text-primary)` overrides at all 3 read sites: `hikelist.component.scss:15` (alongside the existing `background-color` swap), a new `.dropdown-item`/`.dropdown-item:hover` rule in `parkdeck.component.scss`, and `utils.component.scss:9`'s `.badge-transparent` swapped from `var(--bs-list-group-color)` to `var(--app-text-primary)`.


### PR DESCRIPTION
- FEAT: introduce a CSS custom-property token vocabulary (color/spacing/radius/typography/shadow) plus a data-theme dark-mode mechanism with a theme.service localStorage/prefers-color-scheme resolver and a header toggle
- FEAT: retint Bootstrap's contextual and list-group/dropdown colors and add per-component text-color overrides so difficulty icons, badges, hike-list rows, and dropdown items stay legible in dark mode
- REFACTOR: rework the base card system (elevation, radius, hover states) and typography scale that hikedeck/parkdeck/hikelist/ebrpgoal build on
- FIXED: error page never received the shared .app shell due to a capitalized className mismatch
- CHORE: add .claude/dotest.txt test gate, fix stale CRA boilerplate test, and add an npm "publish" script (build + gh-pages -d build)